### PR TITLE
fix: pathname issue with "\(\)"

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,10 +20,7 @@ try {
           case 'win32':
             return `Set-Content -Path '${modulesPath}' -Stream com.dropbox.ignored -Value 1`;
           case 'darwin':
-            return `xattr -w com.dropbox.ignored 1 ${modulesPath.replace(
-              ' ',
-              '\\ '
-            )}`;
+            return `xattr -w com.dropbox.ignored 1 "${modulesPath}"`;
           case 'linux':
             return isWsl
               ? `powershell.exe -Command "Set-Content -Path '${modulesPath.replace(


### PR DESCRIPTION

```shell
# error path: root/Dropbox (Personal)/project
/bin/sh: -c: line 0: syntax error near unexpected token `('
```